### PR TITLE
Ver 0.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,25 +2,9 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
-    paths:
-      - Cargo.toml
     tags:
       - "v*.*.*"
-
 jobs:
-  tag:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-      - uses: salsify/action-detect-and-tag-new-version@v2
-        id: detect_tag
-        with:
-          create-tag: true
-          version-command: cargo read-manifest | jq -r .version
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,21 @@
+name: Tag
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - Cargo.toml
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - uses: salsify/action-detect-and-tag-new-version@v2
+        id: detect_tag
+        with:
+          create-tag: true
+          version-command: cargo read-manifest | jq -r .version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raki"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Norimasa Takana <alignof@outlook.com>"]
 description = "RISC-V instruction decoder written in Rust."

--- a/src/decode/inst_16.rs
+++ b/src/decode/inst_16.rs
@@ -118,8 +118,8 @@ mod decode_16 {
         );
         test_16(0x4521, C_LI, Some(10), None, None, Some(8));
         test_16(0xb5e5, C_J, None, None, None, Some(-280));
-        test_16(0x6105, C_ADDI, None, Some(2), None, Some(32));
-        test_16(0x8082, C_JR, None, Some(1), None, None);
+        test_16(0x6105, C_ADDI, Some(2), Some(2), None, Some(32));
+        test_16(0x8082, C_JR, None, Some(1), Some(0), None);
         test_16(0xe29d, C_BNEZ, None, Some(13), None, Some(38));
         test_16(0xc05c, C_SW, None, Some(8), Some(15), Some(4));
         test_16(0x9002, C_EBREAK, None, None, None, None);

--- a/src/decode/inst_16/c_extension.rs
+++ b/src/decode/inst_16/c_extension.rs
@@ -137,6 +137,7 @@ pub fn parse_rd(inst: u16, opkind: &OpcodeKind) -> Result<Option<usize>, Decodin
         | OpcodeKind::C_LDSP
         | OpcodeKind::C_MV
         | OpcodeKind::C_JALR
+        | OpcodeKind::C_JR
         | OpcodeKind::C_ADD => Ok(Some(q2_rd)),
         _ => Ok(None),
     }
@@ -192,9 +193,12 @@ pub fn parse_rs2(inst: u16, opkind: &OpcodeKind) -> Result<Option<usize>, Decodi
         | OpcodeKind::C_SUBW
         | OpcodeKind::C_ADDW => Ok(Some(q1_rs2)),
         // Quadrant 2
-        OpcodeKind::C_MV | OpcodeKind::C_ADD | OpcodeKind::C_SWSP | OpcodeKind::C_SDSP => {
-            Ok(Some(q2_rs2))
-        }
+        OpcodeKind::C_JR
+        | OpcodeKind::C_JALR
+        | OpcodeKind::C_MV
+        | OpcodeKind::C_ADD
+        | OpcodeKind::C_SWSP
+        | OpcodeKind::C_SDSP => Ok(Some(q2_rs2)),
         _ => Ok(None),
     }
 }

--- a/src/decode/inst_16/c_extension.rs
+++ b/src/decode/inst_16/c_extension.rs
@@ -126,9 +126,11 @@ pub fn parse_rd(inst: u16, opkind: &OpcodeKind) -> Result<Option<usize>, Decodin
         | OpcodeKind::C_AND
         | OpcodeKind::C_ADDW
         | OpcodeKind::C_SUBW => Ok(Some(q1_rd)),
-        OpcodeKind::C_LI | OpcodeKind::C_LUI | OpcodeKind::C_ADDI | OpcodeKind::C_ADDIW => {
-            Ok(Some(q1_wide_rd))
-        }
+        OpcodeKind::C_LI
+        | OpcodeKind::C_LUI
+        | OpcodeKind::C_ADDI
+        | OpcodeKind::C_ADDIW
+        | OpcodeKind::C_ADDI16SP => Ok(Some(q1_wide_rd)),
         // Quadrant 2
         OpcodeKind::C_SLLI
         | OpcodeKind::C_LWSP

--- a/src/decode/inst_16/c_extension.rs
+++ b/src/decode/inst_16/c_extension.rs
@@ -136,8 +136,6 @@ pub fn parse_rd(inst: u16, opkind: &OpcodeKind) -> Result<Option<usize>, Decodin
         | OpcodeKind::C_LWSP
         | OpcodeKind::C_LDSP
         | OpcodeKind::C_MV
-        | OpcodeKind::C_JALR
-        | OpcodeKind::C_JR
         | OpcodeKind::C_ADD => Ok(Some(q2_rd)),
         _ => Ok(None),
     }

--- a/src/decode/inst_32/zicsr_extension.rs
+++ b/src/decode/inst_32/zicsr_extension.rs
@@ -38,13 +38,8 @@ pub fn parse_rs1(inst: u32, opkind: &OpcodeKind) -> Result<Option<usize>, Decodi
 
     // LUI, AUIPC, JAL, FENCE, ECALL, EBREAK
     match opkind {
-        OpcodeKind::CSRRW
-        | OpcodeKind::CSRRS
-        | OpcodeKind::CSRRC
-        | OpcodeKind::CSRRWI
-        | OpcodeKind::CSRRSI
-        | OpcodeKind::CSRRCI => Ok(Some(rs1)),
-        _ => panic!("This instruction does not have rs1"),
+        OpcodeKind::CSRRW | OpcodeKind::CSRRS | OpcodeKind::CSRRC => Ok(Some(rs1)),
+        _ => Ok(None),
     }
 }
 
@@ -62,6 +57,10 @@ pub fn parse_rs2(inst: u32, opkind: &OpcodeKind) -> Result<Option<usize>, Decodi
     }
 }
 
-pub fn parse_imm(_inst: u32, _opkind: &OpcodeKind) -> Result<Option<i32>, DecodingError> {
-    Ok(None)
+pub fn parse_imm(inst: u32, opkind: &OpcodeKind) -> Result<Option<i32>, DecodingError> {
+    let uimm: i32 = inst.slice(19, 15) as i32;
+    match opkind {
+        OpcodeKind::CSRRWI | OpcodeKind::CSRRSI | OpcodeKind::CSRRCI => Ok(Some(uimm)),
+        _ => Ok(None),
+    }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -26,7 +26,7 @@ pub struct Instruction {
 impl Display for Instruction {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self.inst_format {
-            InstFormat::C_Q1_Rtype | InstFormat::Rtype | InstFormat::Mtype | InstFormat::Atype => {
+            InstFormat::Rtype | InstFormat::Mtype | InstFormat::Atype => {
                 write!(
                     f,
                     "{} {}, {}, {}",
@@ -45,7 +45,7 @@ impl Display for Instruction {
                     reg2str(self.rs1.unwrap()),
                 )
             }
-            InstFormat::A_LRtype | InstFormat::Itype | InstFormat::C_Q0_Itype => write!(
+            InstFormat::CLtype | InstFormat::A_LRtype | InstFormat::Itype => write!(
                 f,
                 "{} {}, {}, {}",
                 self.opc.to_string(),
@@ -53,7 +53,7 @@ impl Display for Instruction {
                 reg2str(self.rs1.unwrap()),
                 self.imm.unwrap()
             ),
-            InstFormat::C_Stype | InstFormat::Stype | InstFormat::Btype => write!(
+            InstFormat::CStype | InstFormat::Stype | InstFormat::Btype => write!(
                 f,
                 "{} {}, {}({})",
                 self.opc.to_string(),
@@ -61,19 +61,25 @@ impl Display for Instruction {
                 self.imm.unwrap(),
                 reg2str(self.rs2.unwrap()),
             ),
-            InstFormat::C_Q1_Itype | InstFormat::C_Q2_Itype => {
+            InstFormat::CIWtype => {
                 write!(
                     f,
-                    "{} {}, {}",
+                    "{} {}, sp, {:x}",
                     self.opc.to_string(),
                     reg2str(self.rd.unwrap()),
                     self.imm.unwrap()
                 )
             }
-            InstFormat::C_Q0_SPtype
-            | InstFormat::Utype
-            | InstFormat::Jtype
-            | InstFormat::C_Utype => {
+            InstFormat::CSStype => {
+                write!(
+                    f,
+                    "{} {}, {}(sp)",
+                    self.opc.to_string(),
+                    reg2str(self.rs2.unwrap()),
+                    self.imm.unwrap()
+                )
+            }
+            InstFormat::Utype | InstFormat::Jtype => {
                 write!(
                     f,
                     "{} {}, {:#x}",
@@ -82,36 +88,35 @@ impl Display for Instruction {
                     self.imm.unwrap()
                 )
             }
-            InstFormat::C_Q2_Rtype => {
+            InstFormat::CJtype => {
+                write!(f, "{} {}", self.opc.to_string(), self.imm.unwrap())
+            }
+            InstFormat::CItype => {
                 write!(
                     f,
-                    "{} {}, {}",
+                    "{} {}, {}, {}",
                     self.opc.to_string(),
+                    reg2str(self.rd.unwrap()),
+                    reg2str(self.rd.unwrap()),
+                    self.imm.unwrap()
+                )
+            }
+            InstFormat::CRtype | InstFormat::CAtype => {
+                write!(
+                    f,
+                    "{} {}, {}, {}",
+                    self.opc.to_string(),
+                    reg2str(self.rd.unwrap()),
                     reg2str(self.rd.unwrap()),
                     reg2str(self.rs2.unwrap())
                 )
             }
-            InstFormat::C_Q1_Jtype | InstFormat::C_Q1_NoRDtype => {
-                write!(f, "{} ({})", self.opc.to_string(), self.imm.unwrap())
-            }
-            InstFormat::C_Q2_Jtype => {
-                write!(f, "{} ({})", self.opc.to_string(), self.rs1.unwrap())
-            }
-            InstFormat::C_Btype => {
+            InstFormat::CBtype => {
                 write!(
                     f,
                     "{} {}, {}",
                     self.opc.to_string(),
                     self.rs1.unwrap(),
-                    self.imm.unwrap(),
-                )
-            }
-            InstFormat::C_Q2_SPtype => {
-                write!(
-                    f,
-                    "{} {}, {}",
-                    self.opc.to_string(),
-                    self.rs2.unwrap(),
                     self.imm.unwrap(),
                 )
             }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -26,7 +26,7 @@ pub struct Instruction {
 impl Display for Instruction {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self.inst_format {
-            InstFormat::Rtype | InstFormat::Mtype | InstFormat::Atype => {
+            InstFormat::Rformat | InstFormat::Mformat | InstFormat::Aformat => {
                 write!(
                     f,
                     "{} {}, {}, {}",
@@ -36,7 +36,7 @@ impl Display for Instruction {
                     reg2str(self.rs2.unwrap())
                 )
             }
-            InstFormat::R_SHAMTtype => {
+            InstFormat::R_SHAMTformat => {
                 write!(
                     f,
                     "{} {}, {}",
@@ -45,7 +45,7 @@ impl Display for Instruction {
                     reg2str(self.rs1.unwrap()),
                 )
             }
-            InstFormat::CLtype | InstFormat::A_LRtype | InstFormat::Itype => write!(
+            InstFormat::CLformat | InstFormat::A_LRformat | InstFormat::Iformat => write!(
                 f,
                 "{} {}, {}, {}",
                 self.opc.to_string(),
@@ -53,7 +53,7 @@ impl Display for Instruction {
                 reg2str(self.rs1.unwrap()),
                 self.imm.unwrap()
             ),
-            InstFormat::CStype | InstFormat::Stype | InstFormat::Btype => write!(
+            InstFormat::CSformat | InstFormat::Sformat | InstFormat::Bformat => write!(
                 f,
                 "{} {}, {}({})",
                 self.opc.to_string(),
@@ -61,7 +61,7 @@ impl Display for Instruction {
                 self.imm.unwrap(),
                 reg2str(self.rs2.unwrap()),
             ),
-            InstFormat::CIWtype => {
+            InstFormat::CIWformat => {
                 write!(
                     f,
                     "{} {}, sp, {:x}",
@@ -70,7 +70,7 @@ impl Display for Instruction {
                     self.imm.unwrap()
                 )
             }
-            InstFormat::CSStype => {
+            InstFormat::CSSformat => {
                 write!(
                     f,
                     "{} {}, {}(sp)",
@@ -79,7 +79,7 @@ impl Display for Instruction {
                     self.imm.unwrap()
                 )
             }
-            InstFormat::Utype | InstFormat::Jtype => {
+            InstFormat::Uformat | InstFormat::Jformat => {
                 write!(
                     f,
                     "{} {}, {:#x}",
@@ -88,10 +88,10 @@ impl Display for Instruction {
                     self.imm.unwrap()
                 )
             }
-            InstFormat::CJtype => {
+            InstFormat::CJformat => {
                 write!(f, "{} {}", self.opc.to_string(), self.imm.unwrap())
             }
-            InstFormat::CItype => {
+            InstFormat::CIformat => {
                 write!(
                     f,
                     "{} {}, {}, {}",
@@ -101,7 +101,7 @@ impl Display for Instruction {
                     self.imm.unwrap()
                 )
             }
-            InstFormat::CRtype | InstFormat::CAtype => {
+            InstFormat::CRformat | InstFormat::CAformat => {
                 write!(
                     f,
                     "{} {}, {}, {}",
@@ -111,7 +111,7 @@ impl Display for Instruction {
                     reg2str(self.rs2.unwrap())
                 )
             }
-            InstFormat::CBtype => {
+            InstFormat::CBformat => {
                 write!(
                     f,
                     "{} {}, {}",
@@ -120,7 +120,7 @@ impl Display for Instruction {
                     self.imm.unwrap(),
                 )
             }
-            InstFormat::CSRtype => {
+            InstFormat::CSRformat => {
                 write!(
                     f,
                     "{} {}, {:#x}, {}",
@@ -130,7 +130,7 @@ impl Display for Instruction {
                     reg2str(self.rs1.unwrap()),
                 )
             }
-            InstFormat::CSRuitype => {
+            InstFormat::CSRuiformat => {
                 write!(
                     f,
                     "{} {}, {}, {}",
@@ -230,50 +230,50 @@ pub enum InstFormat {
     /// ```ignore
     /// add rd, rs1, rs2
     /// ```
-    Rtype,
+    Rformat,
 
     /// Regular format with shamt
     /// ```ignore
     /// srai rd, rs1
     /// ```
-    R_SHAMTtype,
+    R_SHAMTformat,
 
     /// Immediate format
     /// ```ignore
     /// lw rd, imm(rs1)
     /// ```
-    Itype,
+    Iformat,
 
     /// Store format
     /// ```ignore
     /// sw rs2, imm(rs1)
     /// ```
-    Stype,
+    Sformat,
 
     /// Branch format
     /// ```ignore
     /// beq rs1, rs2, imm
     /// ```
-    Btype,
+    Bformat,
 
     /// Upper immediate format
     /// ```ignore
     /// lui rd, imm
     /// ```
-    Utype,
+    Uformat,
 
     /// Jump format
     /// ```ignore
     /// jal rd, imm
     /// ```
-    Jtype,
+    Jformat,
 
     /// Compressed Register format
     /// ```ignore
     /// c.mv rd, rs2
     /// c.add rd, rd, rs2
     /// ```
-    CRtype,
+    CRformat,
 
     /// Compressed Immediate format
     /// ```ignore
@@ -281,82 +281,82 @@ pub enum InstFormat {
     /// c.addi rd, rd, imm
     /// c.addi16sp x2, x2, nzimm
     /// ```
-    CItype,
+    CIformat,
 
     /// Compressed Stack-relative Store format
     /// ```ignore
     /// c.swsp rs2, imm
     /// -> sw rs2, imm[8:3](x2)
     /// ```
-    CSStype,
+    CSSformat,
 
     /// Compressed Wide Immediate Store format
     /// ```ignore
     /// c.addi4spn rd, x2, nzuimm
     /// ```
-    CIWtype,
+    CIWformat,
 
     /// Compressed Load format
     /// ```ignore
     /// c.lw rd imm(rs1)
     /// ```
-    CLtype,
+    CLformat,
 
     /// Compressed Store format
     /// ```ignore
     /// c.sw rs2, imm(rs1)
     /// ```
-    CStype,
+    CSformat,
 
     /// Compressed Arithmetic format
     /// ```ignore
     /// c.and rd, rd, rs2
     /// ```
-    CAtype,
+    CAformat,
 
     /// Compressed Branch format
     /// ```ignore
     /// c.beqz rs1, imm
     /// c.srai rd, rd, shamt
     /// ```
-    CBtype,
+    CBformat,
 
     /// Compressed Jump format
     /// ```ignore
     /// c.j imm
     /// ```
-    CJtype,
+    CJformat,
 
     /// Compressed Csr format
     /// ```ignore
     /// csrrw rd, csr, rs1
     /// csrrwi rd, csr, imm
     /// ```
-    CSRtype,
+    CSRformat,
 
     /// Csr with uimm format
     /// ```ignore
     /// csrrwi rd, csr, imm
     /// ```
-    CSRuitype,
+    CSRuiformat,
 
     /// M-extension instruction format
     /// ```ignore
     /// mul rd, rs1, rs2
     /// ```
-    Mtype,
+    Mformat,
 
     /// A-extension instruction format
     /// ```ignore
     /// sc.w rd, rs2, (rs1)
     /// ```
-    Atype,
+    Aformat,
 
     /// lr.w instruction format in A-extension
     /// ```ignore
     /// lr.w rd, (rs1)
     /// ```
-    A_LRtype,
+    A_LRformat,
 
     /// Uncategorized format
     /// ```ignore

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -263,88 +263,69 @@ pub enum InstFormat {
     /// ```
     Jtype,
 
-    /// Compressed Immediate format in Quadrant 0
+    /// Compressed Register format
     /// ```ignore
-    /// c.addi4spn rd, nzuimm
+    /// c.mv rd, rs2
+    /// c.add rd, rd, rs2
     /// ```
-    C_Q0_SPtype,
+    CRtype,
 
-    /// Compressed Immediate format in Quadrant 0
+    /// Compressed Immediate format
+    /// ```ignore
+    /// c.nop
+    /// c.addi rd, rd, imm
+    /// c.addi16sp x2, x2, nzimm
+    /// ```
+    CItype,
+
+    /// Compressed Stack-relative Store format
+    /// ```ignore
+    /// c.swsp rs2, imm
+    /// -> sw rs2, imm[8:3](x2)
+    /// ```
+    CSStype,
+
+    /// Compressed Wide Immediate Store format
+    /// ```ignore
+    /// c.addi4spn rd, x2, nzuimm
+    /// ```
+    CIWtype,
+
+    /// Compressed Load format
     /// ```ignore
     /// c.lw rd imm(rs1)
     /// ```
-    C_Q0_Itype,
+    CLtype,
 
     /// Compressed Store format
     /// ```ignore
     /// c.sw rs2, imm(rs1)
     /// ```
-    C_Stype,
+    CStype,
 
-    /// Compressed Immediate format in Quadrant 1
-    /// ```ignore
-    /// c.addi rd, rd, nzuimm
-    /// ```
-    C_Q1_Itype,
-
-    /// Compressed Jump format in Quadrant 1
-    /// ```ignore
-    /// c.j imm
-    /// ```
-    C_Q1_Jtype,
-
-    /// Compressed instruction does not have rd in Quadrant 1
-    /// ```ignore
-    /// c.addi16sp nzuimm
-    /// ```
-    C_Q1_NoRDtype,
-
-    /// Compressed Upper immediate format (Quadrant 1)
-    /// ```ignore
-    /// c.lui rd, nzuimm
-    /// ```
-    C_Utype,
-
-    /// Compressed Regular format in Quadrant 1
+    /// Compressed Arithmetic format
     /// ```ignore
     /// c.and rd, rd, rs2
     /// ```
-    C_Q1_Rtype,
+    CAtype,
 
-    /// Compressed Branch format (Quadrant 1)
+    /// Compressed Branch format
     /// ```ignore
     /// c.beqz rs1, imm
+    /// c.srai rd, rd, shamt
     /// ```
-    C_Btype,
+    CBtype,
 
-    /// Compressed Immediate format in Quadrant 2
+    /// Compressed Jump format
     /// ```ignore
-    /// c.slli rd, rd, nzuimm
+    /// c.j imm
     /// ```
-    C_Q2_Itype,
-
-    /// Compressed Jump format in Quadrant 2
-    /// ```ignore
-    /// c.jr rs1
-    /// ```
-    C_Q2_Jtype,
-
-    /// Compressed load/store stack pointer instruction in Quadrant 2
-    /// ```ignore
-    /// c.swsp rs2, uimm
-    /// ```
-    C_Q2_SPtype,
-
-    /// Compressed Regular format in Quadrant 2
-    /// ```ignore
-    /// c.add rd, rd, rs2
-    /// c.mv rd, rs2
-    /// ```
-    C_Q2_Rtype,
+    CJtype,
 
     /// Compressed Csr format
     /// ```ignore
     /// csrrw rd, csr, rs1
+    /// csrrwi rd, csr, imm
     /// ```
     CSRtype,
 

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -101,7 +101,34 @@ impl Display for Instruction {
                     self.imm.unwrap()
                 )
             }
-            InstFormat::CRformat | InstFormat::CAformat => {
+            InstFormat::CRformat => match self.opc {
+                OpcodeKind::C_JR | OpcodeKind::C_JALR => {
+                    write!(
+                        f,
+                        "{} {}, 0({})",
+                        self.opc.to_string(),
+                        reg2str(self.rs1.unwrap()),
+                        self.rs2.unwrap()
+                    )
+                }
+                OpcodeKind::C_MV => write!(
+                    f,
+                    "{} {}, {}",
+                    self.opc.to_string(),
+                    reg2str(self.rd.unwrap()),
+                    reg2str(self.rs2.unwrap())
+                ),
+                OpcodeKind::C_ADD => write!(
+                    f,
+                    "{} {}, {}, {}",
+                    self.opc.to_string(),
+                    reg2str(self.rd.unwrap()),
+                    reg2str(self.rd.unwrap()),
+                    reg2str(self.rs2.unwrap())
+                ),
+                _ => unreachable!(),
+            },
+            InstFormat::CAformat => {
                 write!(
                     f,
                     "{} {}, {}, {}",

--- a/src/instruction/opcode.rs
+++ b/src/instruction/opcode.rs
@@ -106,28 +106,33 @@ impl OpcodeKind {
 
             // Compressed
             // Quadrant 0
-            OpcodeKind::C_ADDI4SPN => InstFormat::C_Q0_SPtype,
-            OpcodeKind::C_LW | OpcodeKind::C_LD => InstFormat::C_Q0_Itype,
-            OpcodeKind::C_SW | OpcodeKind::C_SD => InstFormat::C_Stype,
+            OpcodeKind::C_LW | OpcodeKind::C_LD => InstFormat::CLtype,
+            OpcodeKind::C_ADDI4SPN => InstFormat::CIWtype,
+            OpcodeKind::C_SW | OpcodeKind::C_SD => InstFormat::CStype,
             // Quadrant 1
-            OpcodeKind::C_BEQZ | OpcodeKind::C_BNEZ => InstFormat::C_Btype,
-            OpcodeKind::C_JAL | OpcodeKind::C_J => InstFormat::C_Q1_Jtype,
-            OpcodeKind::C_NOP | OpcodeKind::C_ADDI16SP => InstFormat::C_Q1_NoRDtype,
-            OpcodeKind::C_ANDI | OpcodeKind::C_SRLI | OpcodeKind::C_SRAI => InstFormat::C_Q1_Itype,
-            OpcodeKind::C_ADDI | OpcodeKind::C_LI | OpcodeKind::C_ADDIW | OpcodeKind::C_LUI => {
-                InstFormat::C_Q1_Itype
-            }
+            OpcodeKind::C_JAL | OpcodeKind::C_J => InstFormat::CJtype,
+            OpcodeKind::C_BEQZ
+            | OpcodeKind::C_ANDI
+            | OpcodeKind::C_SRLI
+            | OpcodeKind::C_SRAI
+            | OpcodeKind::C_BNEZ => InstFormat::CBtype,
+            OpcodeKind::C_LI
+            | OpcodeKind::C_ADDI
+            | OpcodeKind::C_ADDIW
+            | OpcodeKind::C_ADDI16SP
+            | OpcodeKind::C_NOP
+            | OpcodeKind::C_LUI => InstFormat::CItype,
             OpcodeKind::C_SUB
             | OpcodeKind::C_XOR
             | OpcodeKind::C_OR
             | OpcodeKind::C_AND
             | OpcodeKind::C_SUBW
-            | OpcodeKind::C_ADDW => InstFormat::C_Q1_Rtype,
+            | OpcodeKind::C_ADDW => InstFormat::CAtype,
             // Quadrant 2
-            OpcodeKind::C_SDSP | OpcodeKind::C_SWSP => InstFormat::C_Q2_SPtype,
-            OpcodeKind::C_JR | OpcodeKind::C_JALR => InstFormat::C_Q2_Jtype,
-            OpcodeKind::C_LDSP | OpcodeKind::C_LWSP | OpcodeKind::C_SLLI => InstFormat::C_Q2_Itype,
-            OpcodeKind::C_MV | OpcodeKind::C_ADD => InstFormat::C_Q2_Rtype,
+            OpcodeKind::C_LDSP | OpcodeKind::C_SLLI | OpcodeKind::C_LWSP => InstFormat::CItype,
+            OpcodeKind::C_SDSP | OpcodeKind::C_SWSP => InstFormat::CSStype,
+            OpcodeKind::C_MV | OpcodeKind::C_ADD => InstFormat::CRtype,
+            OpcodeKind::C_JR | OpcodeKind::C_JALR => InstFormat::CJtype,
             OpcodeKind::C_EBREAK => InstFormat::Uncategorized,
         }
     }

--- a/src/instruction/opcode.rs
+++ b/src/instruction/opcode.rs
@@ -120,8 +120,8 @@ impl OpcodeKind {
             | OpcodeKind::C_ADDI
             | OpcodeKind::C_ADDIW
             | OpcodeKind::C_ADDI16SP
-            | OpcodeKind::C_NOP
             | OpcodeKind::C_LUI => InstFormat::CItype,
+            OpcodeKind::C_NOP => InstFormat::Uncategorized,
             OpcodeKind::C_SUB
             | OpcodeKind::C_XOR
             | OpcodeKind::C_OR
@@ -131,8 +131,9 @@ impl OpcodeKind {
             // Quadrant 2
             OpcodeKind::C_LDSP | OpcodeKind::C_SLLI | OpcodeKind::C_LWSP => InstFormat::CItype,
             OpcodeKind::C_SDSP | OpcodeKind::C_SWSP => InstFormat::CSStype,
-            OpcodeKind::C_MV | OpcodeKind::C_ADD => InstFormat::CRtype,
-            OpcodeKind::C_JR | OpcodeKind::C_JALR => InstFormat::CJtype,
+            OpcodeKind::C_JR | OpcodeKind::C_JALR | OpcodeKind::C_MV | OpcodeKind::C_ADD => {
+                InstFormat::CRtype
+            }
             OpcodeKind::C_EBREAK => InstFormat::Uncategorized,
         }
     }

--- a/src/instruction/opcode.rs
+++ b/src/instruction/opcode.rs
@@ -11,7 +11,7 @@ impl OpcodeKind {
             | OpcodeKind::BLT
             | OpcodeKind::BGE
             | OpcodeKind::BLTU
-            | OpcodeKind::BGEU => InstFormat::Btype,
+            | OpcodeKind::BGEU => InstFormat::Bformat,
             OpcodeKind::JALR
             | OpcodeKind::LB
             | OpcodeKind::LH
@@ -26,13 +26,13 @@ impl OpcodeKind {
             | OpcodeKind::ANDI
             | OpcodeKind::LWU
             | OpcodeKind::LD
-            | OpcodeKind::ADDIW => InstFormat::Itype,
+            | OpcodeKind::ADDIW => InstFormat::Iformat,
             OpcodeKind::SLLI
             | OpcodeKind::SRLI
             | OpcodeKind::SRAI
             | OpcodeKind::SLLIW
             | OpcodeKind::SRLIW
-            | OpcodeKind::SRAIW => InstFormat::R_SHAMTtype,
+            | OpcodeKind::SRAIW => InstFormat::R_SHAMTformat,
             OpcodeKind::ADD
             | OpcodeKind::SUB
             | OpcodeKind::SLL
@@ -47,10 +47,12 @@ impl OpcodeKind {
             | OpcodeKind::SUBW
             | OpcodeKind::SLLW
             | OpcodeKind::SRLW
-            | OpcodeKind::SRAW => InstFormat::Rtype,
-            OpcodeKind::SB | OpcodeKind::SH | OpcodeKind::SW | OpcodeKind::SD => InstFormat::Stype,
-            OpcodeKind::JAL => InstFormat::Jtype,
-            OpcodeKind::LUI | OpcodeKind::AUIPC => InstFormat::Utype,
+            | OpcodeKind::SRAW => InstFormat::Rformat,
+            OpcodeKind::SB | OpcodeKind::SH | OpcodeKind::SW | OpcodeKind::SD => {
+                InstFormat::Sformat
+            }
+            OpcodeKind::JAL => InstFormat::Jformat,
+            OpcodeKind::LUI | OpcodeKind::AUIPC => InstFormat::Uformat,
             OpcodeKind::ECALL | OpcodeKind::FENCE | OpcodeKind::EBREAK => InstFormat::Uncategorized,
 
             // Zicsr
@@ -59,11 +61,11 @@ impl OpcodeKind {
             | OpcodeKind::CSRRC
             | OpcodeKind::CSRRWI
             | OpcodeKind::CSRRSI
-            | OpcodeKind::CSRRCI => InstFormat::CSRuitype,
+            | OpcodeKind::CSRRCI => InstFormat::CSRuiformat,
 
             // Privileged
             OpcodeKind::SRET | OpcodeKind::MRET | OpcodeKind::WFI => InstFormat::Uncategorized,
-            OpcodeKind::SFENCE_VMA => InstFormat::Rtype,
+            OpcodeKind::SFENCE_VMA => InstFormat::Rformat,
 
             // Multiplication and Division
             OpcodeKind::MUL
@@ -78,10 +80,10 @@ impl OpcodeKind {
             | OpcodeKind::DIVW
             | OpcodeKind::DIVUW
             | OpcodeKind::REMW
-            | OpcodeKind::REMUW => InstFormat::Mtype,
+            | OpcodeKind::REMUW => InstFormat::Mformat,
 
             // Atomic
-            OpcodeKind::LR_W => InstFormat::A_LRtype,
+            OpcodeKind::LR_W => InstFormat::A_LRformat,
             OpcodeKind::SC_W
             | OpcodeKind::AMOSWAP_W
             | OpcodeKind::AMOADD_W
@@ -102,37 +104,37 @@ impl OpcodeKind {
             | OpcodeKind::AMOMIN_D
             | OpcodeKind::AMOMAX_D
             | OpcodeKind::AMOMINU_D
-            | OpcodeKind::AMOMAXU_D => InstFormat::Atype,
+            | OpcodeKind::AMOMAXU_D => InstFormat::Aformat,
 
             // Compressed
             // Quadrant 0
-            OpcodeKind::C_LW | OpcodeKind::C_LD => InstFormat::CLtype,
-            OpcodeKind::C_ADDI4SPN => InstFormat::CIWtype,
-            OpcodeKind::C_SW | OpcodeKind::C_SD => InstFormat::CStype,
+            OpcodeKind::C_LW | OpcodeKind::C_LD => InstFormat::CLformat,
+            OpcodeKind::C_ADDI4SPN => InstFormat::CIWformat,
+            OpcodeKind::C_SW | OpcodeKind::C_SD => InstFormat::CSformat,
             // Quadrant 1
-            OpcodeKind::C_JAL | OpcodeKind::C_J => InstFormat::CJtype,
+            OpcodeKind::C_JAL | OpcodeKind::C_J => InstFormat::CJformat,
             OpcodeKind::C_BEQZ
             | OpcodeKind::C_ANDI
             | OpcodeKind::C_SRLI
             | OpcodeKind::C_SRAI
-            | OpcodeKind::C_BNEZ => InstFormat::CBtype,
+            | OpcodeKind::C_BNEZ => InstFormat::CBformat,
             OpcodeKind::C_LI
             | OpcodeKind::C_ADDI
             | OpcodeKind::C_ADDIW
             | OpcodeKind::C_ADDI16SP
-            | OpcodeKind::C_LUI => InstFormat::CItype,
+            | OpcodeKind::C_LUI => InstFormat::CIformat,
             OpcodeKind::C_NOP => InstFormat::Uncategorized,
             OpcodeKind::C_SUB
             | OpcodeKind::C_XOR
             | OpcodeKind::C_OR
             | OpcodeKind::C_AND
             | OpcodeKind::C_SUBW
-            | OpcodeKind::C_ADDW => InstFormat::CAtype,
+            | OpcodeKind::C_ADDW => InstFormat::CAformat,
             // Quadrant 2
-            OpcodeKind::C_LDSP | OpcodeKind::C_SLLI | OpcodeKind::C_LWSP => InstFormat::CItype,
-            OpcodeKind::C_SDSP | OpcodeKind::C_SWSP => InstFormat::CSStype,
+            OpcodeKind::C_LDSP | OpcodeKind::C_SLLI | OpcodeKind::C_LWSP => InstFormat::CIformat,
+            OpcodeKind::C_SDSP | OpcodeKind::C_SWSP => InstFormat::CSSformat,
             OpcodeKind::C_JR | OpcodeKind::C_JALR | OpcodeKind::C_MV | OpcodeKind::C_ADD => {
-                InstFormat::CRtype
+                InstFormat::CRformat
             }
             OpcodeKind::C_EBREAK => InstFormat::Uncategorized,
         }


### PR DESCRIPTION
- Fix `zicsr` decoding.
- Modify to fllow the compressed format in official specification.
- Fix `c.jr` and `c.addi16sp` to get rd value.
- Rename `Xtype` to `Xformat` in `InstFormat`.
- Add Tag workflow.