### PR TITLE
Ver 0.1.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raki"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Norimasa Takana <alignof@outlook.com>"]
 repository = "https://github.com/Alignof/raki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "raki"
 version = "0.1.2"
 edition = "2021"
 authors = ["Norimasa Takana <alignof@outlook.com>"]
+repository = "https://github.com/Alignof/raki"
+keywords = ["risc-v", "docoder"]
 description = "RISC-V instruction decoder written in Rust."
 license = "MIT"
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -112,7 +112,7 @@ trait DecodeUtil {
     fn set(self, mask: &[u32]) -> u32;
 
     /// Get `Extensions` from a u16/u32 value.
-    fn extension(self) -> Extensions;
+    fn extension(self) -> Result<Extensions, DecodingError>;
 
     /// Convert i32 to a sign-extended any size number.
     /// # Arguments

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -50,6 +50,8 @@ pub enum DecodingError {
     InvalidFunct7,
     /// Has an opcode that cannot be decoded.
     InvalidOpcode,
+    /// This instruction is included in the unknown extension.
+    UnknownExtension,
     /// Illegal instruction (e.g. all zero value instruction)
     IllegalInstruction,
     /// This instruction is only for Rv64 but appeared at Rv32.

--- a/src/decode/inst_16.rs
+++ b/src/decode/inst_16.rs
@@ -32,35 +32,35 @@ impl Decode for u16 {
 
     fn parse_opcode(self, isa: Isa) -> Result<OpcodeKind, DecodingError> {
         match self.extension() {
-            Extensions::C => c_extension::parse_opcode(self, isa),
+            Ok(Extensions::C) => c_extension::parse_opcode(self, isa),
             _ => Err(DecodingError::Not16BitInst),
         }
     }
 
     fn parse_rd(self, opkind: &OpcodeKind) -> Result<Option<usize>, DecodingError> {
         match self.extension() {
-            Extensions::C => c_extension::parse_rd(self, opkind),
+            Ok(Extensions::C) => c_extension::parse_rd(self, opkind),
             _ => Err(DecodingError::Not16BitInst),
         }
     }
 
     fn parse_rs1(self, opkind: &OpcodeKind) -> Result<Option<usize>, DecodingError> {
         match self.extension() {
-            Extensions::C => c_extension::parse_rs1(self, opkind),
+            Ok(Extensions::C) => c_extension::parse_rs1(self, opkind),
             _ => Err(DecodingError::Not16BitInst),
         }
     }
 
     fn parse_rs2(self, opkind: &OpcodeKind) -> Result<Option<usize>, DecodingError> {
         match self.extension() {
-            Extensions::C => c_extension::parse_rs2(self, opkind),
+            Ok(Extensions::C) => c_extension::parse_rs2(self, opkind),
             _ => Err(DecodingError::Not16BitInst),
         }
     }
 
     fn parse_imm(self, opkind: &OpcodeKind, _isa: Isa) -> Result<Option<i32>, DecodingError> {
         match self.extension() {
-            Extensions::C => c_extension::parse_imm(self, opkind),
+            Ok(Extensions::C) => c_extension::parse_imm(self, opkind),
             _ => Err(DecodingError::Not16BitInst),
         }
     }
@@ -80,8 +80,8 @@ impl DecodeUtil for u16 {
         inst
     }
 
-    fn extension(self) -> Extensions {
-        Extensions::C
+    fn extension(self) -> Result<Extensions, DecodingError> {
+        Ok(Extensions::C)
     }
 }
 

--- a/src/decode/inst_32.rs
+++ b/src/decode/inst_32.rs
@@ -32,56 +32,61 @@ impl Decode for u32 {
 
     fn parse_opcode(self, isa: Isa) -> Result<OpcodeKind, DecodingError> {
         match self.extension() {
-            Extensions::BaseI => base_i::parse_opcode(self, isa),
-            Extensions::M => m_extension::parse_opcode(self, isa),
-            Extensions::A => a_extension::parse_opcode(self, isa),
-            Extensions::Zicsr => zicsr_extension::parse_opcode(self),
-            Extensions::Priv => priv_extension::parse_opcode(self),
-            Extensions::C => Err(DecodingError::Not32BitInst),
+            Ok(Extensions::BaseI) => base_i::parse_opcode(self, isa),
+            Ok(Extensions::M) => m_extension::parse_opcode(self, isa),
+            Ok(Extensions::A) => a_extension::parse_opcode(self, isa),
+            Ok(Extensions::Zicsr) => zicsr_extension::parse_opcode(self),
+            Ok(Extensions::Priv) => priv_extension::parse_opcode(self),
+            Ok(Extensions::C) => Err(DecodingError::Not32BitInst),
+            Err(decoding_err) => Err(decoding_err),
         }
     }
 
     fn parse_rd(self, opkind: &OpcodeKind) -> Result<Option<usize>, DecodingError> {
         match self.extension() {
-            Extensions::BaseI => base_i::parse_rd(self, opkind),
-            Extensions::M => m_extension::parse_rd(self, opkind),
-            Extensions::A => a_extension::parse_rd(self, opkind),
-            Extensions::Zicsr => zicsr_extension::parse_rd(self, opkind),
-            Extensions::Priv => priv_extension::parse_rd(self, opkind),
-            Extensions::C => Err(DecodingError::Not32BitInst),
+            Ok(Extensions::BaseI) => base_i::parse_rd(self, opkind),
+            Ok(Extensions::M) => m_extension::parse_rd(self, opkind),
+            Ok(Extensions::A) => a_extension::parse_rd(self, opkind),
+            Ok(Extensions::Zicsr) => zicsr_extension::parse_rd(self, opkind),
+            Ok(Extensions::Priv) => priv_extension::parse_rd(self, opkind),
+            Ok(Extensions::C) => Err(DecodingError::Not32BitInst),
+            Err(decoding_err) => Err(decoding_err),
         }
     }
 
     fn parse_rs1(self, opkind: &OpcodeKind) -> Result<Option<usize>, DecodingError> {
         match self.extension() {
-            Extensions::BaseI => base_i::parse_rs1(self, opkind),
-            Extensions::M => m_extension::parse_rs1(self, opkind),
-            Extensions::A => a_extension::parse_rs1(self, opkind),
-            Extensions::Zicsr => zicsr_extension::parse_rs1(self, opkind),
-            Extensions::Priv => priv_extension::parse_rs1(self, opkind),
-            Extensions::C => Err(DecodingError::Not32BitInst),
+            Ok(Extensions::BaseI) => base_i::parse_rs1(self, opkind),
+            Ok(Extensions::M) => m_extension::parse_rs1(self, opkind),
+            Ok(Extensions::A) => a_extension::parse_rs1(self, opkind),
+            Ok(Extensions::Zicsr) => zicsr_extension::parse_rs1(self, opkind),
+            Ok(Extensions::Priv) => priv_extension::parse_rs1(self, opkind),
+            Ok(Extensions::C) => Err(DecodingError::Not32BitInst),
+            Err(decoding_err) => Err(decoding_err),
         }
     }
 
     fn parse_rs2(self, opkind: &OpcodeKind) -> Result<Option<usize>, DecodingError> {
         match self.extension() {
-            Extensions::BaseI => base_i::parse_rs2(self, opkind),
-            Extensions::M => m_extension::parse_rs2(self, opkind),
-            Extensions::A => a_extension::parse_rs2(self, opkind),
-            Extensions::Zicsr => zicsr_extension::parse_rs2(self, opkind),
-            Extensions::Priv => priv_extension::parse_rs2(self, opkind),
-            Extensions::C => Err(DecodingError::Not32BitInst),
+            Ok(Extensions::BaseI) => base_i::parse_rs2(self, opkind),
+            Ok(Extensions::M) => m_extension::parse_rs2(self, opkind),
+            Ok(Extensions::A) => a_extension::parse_rs2(self, opkind),
+            Ok(Extensions::Zicsr) => zicsr_extension::parse_rs2(self, opkind),
+            Ok(Extensions::Priv) => priv_extension::parse_rs2(self, opkind),
+            Ok(Extensions::C) => Err(DecodingError::Not32BitInst),
+            Err(decoding_err) => Err(decoding_err),
         }
     }
 
     fn parse_imm(self, opkind: &OpcodeKind, isa: Isa) -> Result<Option<i32>, DecodingError> {
         match self.extension() {
-            Extensions::BaseI => base_i::parse_imm(self, opkind, isa),
-            Extensions::M => m_extension::parse_imm(self, opkind),
-            Extensions::A => a_extension::parse_imm(self, opkind),
-            Extensions::Zicsr => zicsr_extension::parse_imm(self, opkind),
-            Extensions::Priv => priv_extension::parse_imm(self, opkind),
-            Extensions::C => Err(DecodingError::Not32BitInst),
+            Ok(Extensions::BaseI) => base_i::parse_imm(self, opkind, isa),
+            Ok(Extensions::M) => m_extension::parse_imm(self, opkind),
+            Ok(Extensions::A) => a_extension::parse_imm(self, opkind),
+            Ok(Extensions::Zicsr) => zicsr_extension::parse_imm(self, opkind),
+            Ok(Extensions::Priv) => priv_extension::parse_imm(self, opkind),
+            Ok(Extensions::C) => Err(DecodingError::Not32BitInst),
+            Err(decoding_err) => Err(decoding_err),
         }
     }
 }
@@ -100,30 +105,30 @@ impl DecodeUtil for u32 {
         inst
     }
 
-    fn extension(self) -> Extensions {
+    fn extension(self) -> Result<Extensions, DecodingError> {
         let opmap: u8 = self.slice(6, 0) as u8;
         let funct3: u8 = self.slice(14, 12) as u8;
         let funct7: u8 = self.slice(31, 25) as u8;
 
         match opmap {
-            0b010_1111 => Extensions::A,
+            0b010_1111 => Ok(Extensions::A),
             0b011_0011 => match funct7 {
-                0b000_0001 => Extensions::M,
-                _ => Extensions::BaseI,
+                0b000_0001 => Ok(Extensions::M),
+                _ => Ok(Extensions::BaseI),
             },
             0b011_1011 => match funct7 {
-                0b000_0000 | 0b010_0000 => Extensions::BaseI,
-                0b000_0001 => Extensions::M,
-                _ => unreachable!(),
+                0b000_0000 | 0b010_0000 => Ok(Extensions::BaseI),
+                0b000_0001 => Ok(Extensions::M),
+                _ => Err(DecodingError::UnknownExtension),
             },
             0b111_0011 => match funct3 {
                 0b000 => match funct7 {
-                    0b000_0000 => Extensions::BaseI,
-                    _ => Extensions::Priv,
+                    0b000_0000 => Ok(Extensions::BaseI),
+                    _ => Ok(Extensions::Priv),
                 },
-                _ => Extensions::Zicsr,
+                _ => Ok(Extensions::Zicsr),
             },
-            _ => Extensions::BaseI,
+            _ => Ok(Extensions::BaseI),
         }
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -26,7 +26,7 @@ pub struct Instruction {
 impl Display for Instruction {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self.inst_format {
-            InstFormat::Rformat | InstFormat::Mformat | InstFormat::Aformat => {
+            InstFormat::Rformat | InstFormat::Mformat => {
                 write!(
                     f,
                     "{} {}, {}, {}",
@@ -36,6 +36,23 @@ impl Display for Instruction {
                     reg2str(self.rs2.unwrap())
                 )
             }
+            InstFormat::Aformat => match self.opc {
+                OpcodeKind::LR_W | OpcodeKind::LR_D => write!(
+                    f,
+                    "{} {}, {}",
+                    self.opc.to_string(),
+                    reg2str(self.rd.unwrap()),
+                    reg2str(self.rs1.unwrap()),
+                ),
+                _ => write!(
+                    f,
+                    "{} {}, {}, {}",
+                    self.opc.to_string(),
+                    reg2str(self.rd.unwrap()),
+                    reg2str(self.rs1.unwrap()),
+                    reg2str(self.rs2.unwrap())
+                ),
+            },
             InstFormat::R_SHAMTformat => {
                 write!(
                     f,

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -102,13 +102,20 @@ impl Display for Instruction {
                 )
             }
             InstFormat::CRformat => match self.opc {
-                OpcodeKind::C_JR | OpcodeKind::C_JALR => {
+                OpcodeKind::C_JR => {
                     write!(
                         f,
-                        "{} {}, 0({})",
+                        "{} zero, 0({})",
                         self.opc.to_string(),
                         reg2str(self.rs1.unwrap()),
-                        self.rs2.unwrap()
+                    )
+                }
+                OpcodeKind::C_JALR => {
+                    write!(
+                        f,
+                        "{} ra, 0({})",
+                        self.opc.to_string(),
+                        reg2str(self.rs1.unwrap()),
                     )
                 }
                 OpcodeKind::C_MV => write!(

--- a/src/instruction/opcode.rs
+++ b/src/instruction/opcode.rs
@@ -56,12 +56,8 @@ impl OpcodeKind {
             OpcodeKind::ECALL | OpcodeKind::FENCE | OpcodeKind::EBREAK => InstFormat::Uncategorized,
 
             // Zicsr
-            OpcodeKind::CSRRW
-            | OpcodeKind::CSRRS
-            | OpcodeKind::CSRRC
-            | OpcodeKind::CSRRWI
-            | OpcodeKind::CSRRSI
-            | OpcodeKind::CSRRCI => InstFormat::CSRuiformat,
+            OpcodeKind::CSRRW | OpcodeKind::CSRRS | OpcodeKind::CSRRC => InstFormat::CSRformat,
+            OpcodeKind::CSRRWI | OpcodeKind::CSRRSI | OpcodeKind::CSRRCI => InstFormat::CSRuiformat,
 
             // Privileged
             OpcodeKind::SRET | OpcodeKind::MRET | OpcodeKind::WFI => InstFormat::Uncategorized,


### PR DESCRIPTION
- Fix `C_JR` and `C_JALR` format.
- Add the `UnknownExtension` to `DecodingError`.
- Fix `InstFormat` of `CSRR(W|S|C)`.
- Update `Aformat` formatting.