### PR TITLE
Ver 1.0.0-beta.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raki"
-version = "0.1.3"
+version = "1.0.0-beta.1"
 edition = "2021"
 authors = ["Norimasa Takana <alignof@outlook.com>"]
 repository = "https://github.com/Alignof/raki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2021"
 authors = ["Norimasa Takana <alignof@outlook.com>"]
 repository = "https://github.com/Alignof/raki"
 keywords = ["risc-v", "decoder"]
+categories = ["encoding", "embedded", "hardware-support", "no-std", "parsing"]
 description = "RISC-V instruction decoder written in Rust."
 license = "MIT"
+readme = "README.md"
 
 [lints.clippy]
 pedantic = "warn"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ println!("{inst}");
 // addi t0, t0, -276
 ```
 
+## Support
+- [x] BaseI (RV32I, RV64I)
+- [x] M
+- [x] A
+- [ ] D
+- [ ] G
+- [ ] Q
+- [x] C
+- [ ] B
+- [ ] P
+- [ ] V
+- [ ] H
+- [x] Zicsr
+- [x] Zifencei
+- [ ] Priv (Now only supports `mret`, `sret`, `wfi`, `sfence.vma`)
+
 ## License
 This crate is licensed under MIT.  
 See `LICENSE` for details.

--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@ RISC-V instruction decoder written in Rust.
 ## Usage
 Call the `decode` as u16/u32 method.
 ```rust
-use raki::Isa;
-use raki::decode::Decode;
-use raki::instruction::Instruction;
+use raki::{BaseIOpcode, Decode, Instruction, Isa, OpcodeKind};
 
-let inst: u32 = 0b1110_1110_1100_0010_1000_0010_1001_0011;
-let inst: Instruction = match inst.decode(Isa::Rv32) {
-    Ok(inst) => inst,
-    Err(e) => panic!("decoding failed due to {e:?}"),
-};
-println!("{inst}");
+fn main() {
+    let inst_bytes: u32 = 0b1110_1110_1100_0010_1000_0010_1001_0011;
+    let inst: Instruction = match inst_bytes.decode(Isa::Rv32) {
+        Ok(inst) => inst,
+        Err(e) => panic!("decoding failed due to {e:?}"),
+    };
+
+    assert_eq!(inst.opc, OpcodeKind::BaseI(BaseIOpcode::ADDI));
+    println!("{inst}");
+}
 // --output--
 // addi t0, t0, -276
 ```

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -18,9 +18,7 @@ fn only_rv64<T: Opcode>(opcode: T, isa: Isa) -> Result<T, DecodingError> {
 ///
 /// # Example
 /// ```
-/// use raki::Isa;
-/// use raki::decode::{Decode, DecodingError};
-/// use raki::instruction::Instruction;
+/// use raki::{Isa, Decode, DecodingError, Instruction};
 ///
 /// // try to decode illegal instruction.
 /// let illegal_inst: u32 = 0b0000_0000_0000_0000_0000_0000_0000_0000;
@@ -65,8 +63,7 @@ pub enum DecodingError {
 /// `decode` method is implemented for u16/u32.
 /// thus, just call `decode` as method of u16/u32.
 /// ```
-/// use raki::Isa;
-/// use raki::decode::Decode;
+/// use raki::{Isa, Decode};
 ///
 /// let inst: u32 = 0b1110_1110_1100_0010_1000_0010_1001_0011;
 /// println!("{:?}", inst.decode(Isa::Rv64));

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3,8 +3,8 @@
 mod inst_16;
 mod inst_32;
 
-use crate::instruction::{Extensions, Instruction, Opcode, OpcodeKind};
-use crate::Isa;
+use crate::instruction::{Instruction, Opcode, OpcodeKind};
+use crate::{Extensions, Isa};
 
 /// Return Err if given opcode is only available on Rv64.
 fn only_rv64<T: Opcode>(opcode: T, isa: Isa) -> Result<T, DecodingError> {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -59,6 +59,7 @@ pub enum DecodingError {
 }
 
 /// A trait to decode an instruction from u16/u32.
+/// This trait provides public api.
 ///
 /// # Usage
 /// `decode` method is implemented for u16/u32.
@@ -76,31 +77,31 @@ pub trait Decode {
     /// # Errors
     /// It will throws an error if target bytes is invalid for decoding.
     fn decode(&self, isa: Isa) -> Result<Instruction, DecodingError>;
-    /// Parse extension from a u16/u32 value.
-    ///
-    /// # Errors
-    /// It will throws `UnknownExtension` if the extension is unsupported.
-    fn parse_extension(self) -> Result<Extensions, DecodingError>;
+
     /// Parse opcode.
     ///
     /// # Errors
     /// It will throws an error if opcode is unknown.
     fn parse_opcode(self, isa: Isa) -> Result<OpcodeKind, DecodingError>;
+
     /// Parse destination register.
     ///
     /// # Errors
     /// It will throws an error if rd is invalid.
     fn parse_rd(self, opkind: &OpcodeKind) -> Result<Option<usize>, DecodingError>;
+
     /// Parse source register 1.
     ///
     /// # Errors
     /// It will throws an error if rs1 is invalid.
     fn parse_rs1(self, opkind: &OpcodeKind) -> Result<Option<usize>, DecodingError>;
+
     /// Parse source register 2.
     ///
     /// # Errors
     /// It will throws an error if rs2 is invalid.
     fn parse_rs2(self, opkind: &OpcodeKind) -> Result<Option<usize>, DecodingError>;
+
     /// Parse immediate.
     ///
     /// # Errors
@@ -109,6 +110,7 @@ pub trait Decode {
 }
 
 /// A trait to help decoding.
+/// This trait provides private api.
 trait DecodeUtil {
     /// Obtains bits in a specified range.
     /// The range is `[end, start]`.
@@ -133,6 +135,12 @@ trait DecodeUtil {
     /// # Arguments
     /// * `mask` - It contain the bit order.
     fn set(self, mask: &[u32]) -> u32;
+
+    /// Parse extension from a u16/u32 value.
+    ///
+    /// # Errors
+    /// It will throws `UnknownExtension` if the extension is unsupported.
+    fn parse_extension(self) -> Result<Extensions, DecodingError>;
 
     /// Convert i32 to a sign-extended any size number.
     /// # Arguments

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -34,7 +34,7 @@ fn only_rv64<T: Opcode>(opcode: T, isa: Isa) -> Result<T, DecodingError> {
 ///     assert!(matches!(error, DecodingError::OnlyRv64Inst));
 /// }
 /// ```
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum DecodingError {
     /// 32bit instructions are expected, but it is compressed instruction.
     Not16BitInst,

--- a/src/decode/inst_16.rs
+++ b/src/decode/inst_16.rs
@@ -2,8 +2,8 @@
 mod c_extension;
 
 use super::{Decode, DecodeUtil, DecodingError};
-use crate::instruction::{Extensions, InstFormat, Instruction, OpcodeKind};
-use crate::Isa;
+use crate::instruction::{InstFormat, Instruction, OpcodeKind};
+use crate::{Extensions, Isa};
 
 impl Decode for u16 {
     fn decode(&self, isa: Isa) -> Result<Instruction, DecodingError> {

--- a/src/decode/inst_16.rs
+++ b/src/decode/inst_16.rs
@@ -28,10 +28,6 @@ impl Decode for u16 {
         })
     }
 
-    fn parse_extension(self) -> Result<Extensions, DecodingError> {
-        Ok(Extensions::C)
-    }
-
     fn parse_opcode(self, isa: Isa) -> Result<OpcodeKind, DecodingError> {
         let extension = self.parse_extension();
 
@@ -73,6 +69,10 @@ impl Decode for u16 {
 impl DecodeUtil for u16 {
     fn slice(self, end: u32, start: u32) -> Self {
         (self >> start) & (2_u16.pow(end - start + 1) - 1)
+    }
+
+    fn parse_extension(self) -> Result<Extensions, DecodingError> {
+        Ok(Extensions::C)
     }
 
     fn set(self, mask: &[u32]) -> u32 {

--- a/src/decode/inst_32.rs
+++ b/src/decode/inst_32.rs
@@ -5,8 +5,8 @@ mod priv_extension;
 mod zicsr_extension;
 
 use super::{Decode, DecodeUtil, DecodingError};
-use crate::instruction::{Extensions, InstFormat, Instruction, OpcodeKind};
-use crate::Isa;
+use crate::instruction::{InstFormat, Instruction, OpcodeKind};
+use crate::{Extensions, Isa};
 
 #[allow(non_snake_case)]
 impl Decode for u32 {

--- a/src/decode/inst_32/base_i.rs
+++ b/src/decode/inst_32/base_i.rs
@@ -91,7 +91,6 @@ pub fn parse_opcode(inst: u32, isa: Isa) -> Result<BaseIOpcode, DecodingError> {
             0b111 => Ok(BaseIOpcode::AND),
             _ => Err(DecodingError::InvalidFunct3),
         },
-        0b000_1111 => Ok(BaseIOpcode::FENCE),
         0b111_0011 => match funct3 {
             0b000 => match funct7 {
                 0b000_0000 => match funct5 {

--- a/src/decode/inst_32/zifencei_extension.rs
+++ b/src/decode/inst_32/zifencei_extension.rs
@@ -1,0 +1,43 @@
+use super::super::{DecodeUtil, DecodingError};
+use crate::instruction::zifencei_extension::ZifenceiOpcode;
+
+pub fn parse_opcode(inst: u32) -> Result<ZifenceiOpcode, DecodingError> {
+    let opmap: u8 = u8::try_from(inst.slice(6, 0)).unwrap();
+
+    match opmap {
+        0b000_1111 => Ok(ZifenceiOpcode::FENCE),
+        _ => Err(DecodingError::InvalidOpcode),
+    }
+}
+
+#[allow(clippy::unnecessary_wraps)]
+pub fn parse_rd(inst: u32, opkind: &ZifenceiOpcode) -> Option<usize> {
+    let rd: usize = inst.slice(11, 7) as usize;
+
+    match opkind {
+        ZifenceiOpcode::FENCE => Some(rd),
+    }
+}
+
+pub fn parse_rs1(inst: u32, opkind: &ZifenceiOpcode) -> Option<usize> {
+    let rs1: usize = inst.slice(19, 15) as usize;
+
+    match opkind {
+        ZifenceiOpcode::FENCE => Some(rs1),
+    }
+}
+
+#[allow(clippy::unnecessary_wraps)]
+pub fn parse_rs2(_inst: u32, opkind: &ZifenceiOpcode) -> Option<usize> {
+    match opkind {
+        ZifenceiOpcode::FENCE => None,
+    }
+}
+
+#[allow(clippy::cast_possible_wrap)]
+pub fn parse_imm(inst: u32, opkind: &ZifenceiOpcode) -> Option<i32> {
+    let fm_pred_succ: u32 = inst.slice(31, 20);
+    match opkind {
+        ZifenceiOpcode::FENCE => Some(fm_pred_succ as i32),
+    }
+}

--- a/src/decode/inst_32/zifencei_extension.rs
+++ b/src/decode/inst_32/zifencei_extension.rs
@@ -19,6 +19,7 @@ pub fn parse_rd(inst: u32, opkind: &ZifenceiOpcode) -> Option<usize> {
     }
 }
 
+#[allow(clippy::unnecessary_wraps)]
 pub fn parse_rs1(inst: u32, opkind: &ZifenceiOpcode) -> Option<usize> {
     let rs1: usize = inst.slice(19, 15) as usize;
 
@@ -34,7 +35,7 @@ pub fn parse_rs2(_inst: u32, opkind: &ZifenceiOpcode) -> Option<usize> {
     }
 }
 
-#[allow(clippy::cast_possible_wrap)]
+#[allow(clippy::cast_possible_wrap, clippy::unnecessary_wraps)]
 pub fn parse_imm(inst: u32, opkind: &ZifenceiOpcode) -> Option<i32> {
     let fm_pred_succ: u32 = inst.slice(31, 20);
     match opkind {

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -17,7 +17,7 @@ use priv_extension::PrivOpcode;
 use zicsr_extension::ZicsrOpcode;
 
 /// Instruction
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Instruction {
     /// Opcode
     pub opc: OpcodeKind,
@@ -277,7 +277,7 @@ pub enum Extensions {
 
 /// Instruction format
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum InstFormat {
     /// Regular format
     /// ```ignore
@@ -429,7 +429,7 @@ pub trait Opcode {
 }
 
 /// Extension type and Instruction name.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum OpcodeKind {
     /// Base Integer Instruction Set
     BaseI(BaseIOpcode),

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -219,6 +219,7 @@ impl Display for Instruction {
     }
 }
 
+/// Convert register number to string.
 fn reg2str(rd_value: usize) -> &'static str {
     match rd_value {
         0 => "zero",

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -6,6 +6,7 @@ pub mod c_extension;
 pub mod m_extension;
 pub mod priv_extension;
 pub mod zicsr_extension;
+pub mod zifencei_extension;
 
 use core::fmt::{self, Display, Formatter};
 
@@ -15,6 +16,7 @@ use c_extension::COpcode;
 use m_extension::MOpcode;
 use priv_extension::PrivOpcode;
 use zicsr_extension::ZicsrOpcode;
+use zifencei_extension::ZifenceiOpcode;
 
 /// Instruction
 #[derive(Debug, PartialEq)]
@@ -422,6 +424,8 @@ pub enum OpcodeKind {
     A(AOpcode),
     /// Compressed Instructions
     C(COpcode),
+    /// Instruction-Fetch Fence,
+    Zifencei(ZifenceiOpcode),
     /// Control and Status Register Instructions
     Zicsr(ZicsrOpcode),
     /// Privileged Instructions
@@ -435,6 +439,7 @@ impl Display for OpcodeKind {
             Self::M(opc) => write!(f, "{opc}"),
             Self::A(opc) => write!(f, "{opc}"),
             Self::C(opc) => write!(f, "{opc}"),
+            Self::Zifencei(opc) => write!(f, "{opc}"),
             Self::Zicsr(opc) => write!(f, "{opc}"),
             Self::Priv(opc) => write!(f, "{opc}"),
         }
@@ -449,6 +454,7 @@ impl OpcodeKind {
             Self::M(opc) => opc.get_format(),
             Self::A(opc) => opc.get_format(),
             Self::C(opc) => opc.get_format(),
+            Self::Zifencei(opc) => opc.get_format(),
             Self::Zicsr(opc) => opc.get_format(),
             Self::Priv(opc) => opc.get_format(),
         }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -258,23 +258,6 @@ fn reg2str(rd_value: usize) -> &'static str {
     }
 }
 
-/// RISC-V extensions
-#[derive(Debug)]
-pub enum Extensions {
-    /// Base Integer Instruction Set
-    BaseI,
-    /// Integer Multiplication and Division
-    M,
-    /// Atomic Instructions
-    A,
-    /// Compressed Instructions
-    C,
-    /// Control and Status Register Instructions
-    Zicsr,
-    /// Privileged Instructions
-    Priv,
-}
-
 /// Instruction format
 #[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq)]

--- a/src/instruction/a_extension.rs
+++ b/src/instruction/a_extension.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Display, Formatter};
 
 /// Insturctions in A Extension.
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum AOpcode {
     LR_W,
     SC_W,

--- a/src/instruction/base_i.rs
+++ b/src/instruction/base_i.rs
@@ -44,7 +44,6 @@ pub enum BaseIOpcode {
     SRA,
     OR,
     AND,
-    FENCE,
     ECALL,
     EBREAK,
 
@@ -103,7 +102,6 @@ impl Display for BaseIOpcode {
             BaseIOpcode::SRA => write!(f, "sra"),
             BaseIOpcode::OR => write!(f, "or"),
             BaseIOpcode::AND => write!(f, "and"),
-            BaseIOpcode::FENCE => write!(f, "fence"),
             BaseIOpcode::ECALL => write!(f, "ecall"),
             BaseIOpcode::EBREAK => write!(f, "ebreak"),
             BaseIOpcode::LWU => write!(f, "lwu"),
@@ -172,9 +170,7 @@ impl Opcode for BaseIOpcode {
             }
             BaseIOpcode::JAL => InstFormat::Jformat,
             BaseIOpcode::LUI | BaseIOpcode::AUIPC => InstFormat::Uformat,
-            BaseIOpcode::ECALL | BaseIOpcode::FENCE | BaseIOpcode::EBREAK => {
-                InstFormat::Uncategorized
-            }
+            BaseIOpcode::ECALL | BaseIOpcode::EBREAK => InstFormat::Uncategorized,
         }
     }
 }

--- a/src/instruction/base_i.rs
+++ b/src/instruction/base_i.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Display, Formatter};
 
 /// Insturctions in Base-I.
 #[allow(non_camel_case_types, clippy::module_name_repetitions)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum BaseIOpcode {
     LUI,
     AUIPC,

--- a/src/instruction/c_extension.rs
+++ b/src/instruction/c_extension.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Display, Formatter};
 
 /// Insturctions in C Extension.
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum COpcode {
     ADDI4SPN,
     LW,

--- a/src/instruction/m_extension.rs
+++ b/src/instruction/m_extension.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Display, Formatter};
 
 /// Insturctions in M Extension.
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum MOpcode {
     MUL,
     MULH,

--- a/src/instruction/m_extension.rs
+++ b/src/instruction/m_extension.rs
@@ -4,7 +4,7 @@ use super::{InstFormat, Opcode};
 use core::fmt::{self, Display, Formatter};
 
 /// Insturctions in M Extension.
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 #[derive(Debug, PartialEq)]
 pub enum MOpcode {
     MUL,

--- a/src/instruction/priv_extension.rs
+++ b/src/instruction/priv_extension.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Display, Formatter};
 
 /// Privileged Insturctions.
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum PrivOpcode {
     SRET,
     MRET,

--- a/src/instruction/priv_extension.rs
+++ b/src/instruction/priv_extension.rs
@@ -7,8 +7,8 @@ use core::fmt::{self, Display, Formatter};
 #[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq)]
 pub enum PrivOpcode {
-    SRET,
     MRET,
+    SRET,
     WFI,
     SFENCE_VMA,
 }

--- a/src/instruction/zicsr_extension.rs
+++ b/src/instruction/zicsr_extension.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Display, Formatter};
 
 /// Insturctions in Zicsr Extension.
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ZicsrOpcode {
     CSRRW,
     CSRRS,

--- a/src/instruction/zifencei_extension.rs
+++ b/src/instruction/zifencei_extension.rs
@@ -3,7 +3,7 @@
 use super::{InstFormat, Opcode};
 use core::fmt::{self, Display, Formatter};
 
-/// Insturctions in Zicsr Extension.
+/// Insturctions in Zifencei Extension.
 #[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq)]
 pub enum ZifenceiOpcode {

--- a/src/instruction/zifencei_extension.rs
+++ b/src/instruction/zifencei_extension.rs
@@ -1,0 +1,27 @@
+//! Zicsr extension Instruction.
+
+use super::{InstFormat, Opcode};
+use core::fmt::{self, Display, Formatter};
+
+/// Insturctions in Zicsr Extension.
+#[allow(non_camel_case_types)]
+#[derive(Debug, PartialEq)]
+pub enum ZifenceiOpcode {
+    FENCE,
+}
+
+impl Display for ZifenceiOpcode {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            ZifenceiOpcode::FENCE => write!(f, "fence.i"),
+        }
+    }
+}
+
+impl Opcode for ZifenceiOpcode {
+    fn get_format(&self) -> InstFormat {
+        match self {
+            ZifenceiOpcode::FENCE => InstFormat::Uncategorized,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,9 @@ mod instruction;
 // re-export
 pub use crate::decode::{Decode, DecodingError};
 pub use crate::instruction::{
-    a_extension::AOpcode, base_i::BaseIOpcode, c_extension::COpcode, priv_extension::PrivOpcode,
-    zicsr_extension::ZicsrOpcode, InstFormat, Instruction, OpcodeKind,
+    a_extension::AOpcode, base_i::BaseIOpcode, c_extension::COpcode, m_extension::MOpcode,
+    priv_extension::PrivOpcode, zicsr_extension::ZicsrOpcode, zifencei_extension::ZifenceiOpcode,
+    InstFormat, Instruction, OpcodeKind,
 };
 
 /// Target isa.
@@ -55,6 +56,8 @@ enum Extensions {
     A,
     /// Compressed Instructions
     C,
+    /// Instruction-Fetch Fence
+    Zifencei,
     /// Control and Status Register Instructions
     Zicsr,
     /// Privileged Instructions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,7 @@
 //! # Usage
 //! Call the `decode` as u16/u32 method.
 //! ```
-//! use raki::Isa;
-//! use raki::decode::Decode;
-//! use raki::instruction::base_i::BaseIOpcode;
-//! use raki::instruction::{Instruction, OpcodeKind};
+//! use raki::{BaseIOpcode, Decode, Instruction, Isa, OpcodeKind};
 //!
 //! fn main() {
 //!     let inst_bytes: u32 = 0b1110_1110_1100_0010_1000_0010_1001_0011;
@@ -28,8 +25,15 @@
 //! // addi t0, t0, -276
 //! ```
 
-pub mod decode;
-pub mod instruction;
+mod decode;
+mod instruction;
+
+// re-export
+pub use crate::decode::{Decode, DecodingError};
+pub use crate::instruction::{
+    a_extension::AOpcode, base_i::BaseIOpcode, c_extension::COpcode, priv_extension::PrivOpcode,
+    zicsr_extension::ZicsrOpcode, InstFormat, Instruction, OpcodeKind,
+};
 
 /// Target isa.
 #[derive(Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,23 @@ pub enum Isa {
     Rv64,
 }
 
+/// RISC-V extensions
+#[derive(Debug)]
+enum Extensions {
+    /// Base Integer Instruction Set
+    BaseI,
+    /// Integer Multiplication and Division
+    M,
+    /// Atomic Instructions
+    A,
+    /// Compressed Instructions
+    C,
+    /// Control and Status Register Instructions
+    Zicsr,
+    /// Privileged Instructions
+    Priv,
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! ```
 //! use raki::{BaseIOpcode, Decode, Instruction, Isa, OpcodeKind};
 //!
-//! fn main() {
+//! fn test() {
 //!     let inst_bytes: u32 = 0b1110_1110_1100_0010_1000_0010_1001_0011;
 //!     let inst: Instruction = match inst_bytes.decode(Isa::Rv32) {
 //!         Ok(inst) => inst,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,4 +90,31 @@ mod tests {
             println!("{inst}");
         }
     }
+
+    #[test]
+    fn inst_eq_test() {
+        use crate::decode::Decode;
+        use crate::instruction::{base_i::BaseIOpcode, InstFormat, Instruction, OpcodeKind};
+        use crate::Isa;
+
+        assert_eq!(
+            0b1111_1111_1001_1111_1111_0000_0110_1111_u32.decode(Isa::Rv64),
+            Ok(Instruction {
+                opc: OpcodeKind::BaseI(BaseIOpcode::JAL),
+                rd: Some(0),
+                rs1: None,
+                rs2: None,
+                imm: Some(-8),
+                inst_format: InstFormat::Jformat,
+            })
+        );
+
+        assert_eq!(
+            0b1111_1111_1001_1111_1111_0000_0110_1111_u32
+                .decode(Isa::Rv64)
+                .unwrap()
+                .opc,
+            OpcodeKind::BaseI(BaseIOpcode::JAL),
+        )
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! ```
 //! use raki::{BaseIOpcode, Decode, Instruction, Isa, OpcodeKind};
 //!
-//! fn test() {
+//! fn example() {
 //!     let inst_bytes: u32 = 0b1110_1110_1100_0010_1000_0010_1001_0011;
 //!     let inst: Instruction = match inst_bytes.decode(Isa::Rv32) {
 //!         Ok(inst) => inst,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,19 @@
 //! ```
 //! use raki::Isa;
 //! use raki::decode::Decode;
-//! use raki::instruction::Instruction;
+//! use raki::instruction::base_i::BaseIOpcode;
+//! use raki::instruction::{Instruction, OpcodeKind};
 //!
-//! let inst: u32 = 0b1110_1110_1100_0010_1000_0010_1001_0011;
-//! let inst: Instruction = match inst.decode(Isa::Rv32) {
-//!     Ok(inst) => inst,
-//!     Err(e) => panic!("decoding failed due to {e:?}"),
-//! };
-//! println!("{inst}");
+//! fn main() {
+//!     let inst_bytes: u32 = 0b1110_1110_1100_0010_1000_0010_1001_0011;
+//!     let inst: Instruction = match inst_bytes.decode(Isa::Rv32) {
+//!         Ok(inst) => inst,
+//!         Err(e) => panic!("decoding failed due to {e:?}"),
+//!     };
+//!
+//!     assert_eq!(inst.opc, OpcodeKind::BaseI(BaseIOpcode::ADDI));
+//!     println!("{inst}");
+//! }
 //! // --output--
 //! // addi t0, t0, -276
 //! ```


### PR DESCRIPTION
- Merge Extension into OpcodeKind. (#14)
- Move instruction definition to each exntesions. (#14)
- Re-export struct and enum in lib.rs
- Support `Zifencei` extension.

Fix #13.