### PR TITLE
Remove `extern crate alloc;`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,6 @@
 //! ```
 #![cfg_attr(not(test), no_std)]
 
-extern crate alloc;
-
 mod decode;
 mod instruction;
 


### PR DESCRIPTION
This is an error in my review of a past pull request and could simply be removed.
Would fix #22 issue.