### PR TITLE
Ver 1.0.1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,8 @@
 //! // addi t0, t0, -276
 //! ```
 #![cfg_attr(not(test), no_std)]
-extern crate alloc;
 
-#![no_std]
+extern crate alloc;
 
 mod decode;
 mod instruction;


### PR DESCRIPTION
- Remove `extern crate alloc;`

The behavior in the no_std environment was confirmed with the following code.  
env: [https://github.com/Alignof/helloworld_in_riscv_and_rust_baremetal](https://github.com/Alignof/helloworld_in_riscv_and_rust_baremetal)
```rust
#![no_main]
#![no_std]

extern crate panic_halt;

use raki::{BaseIOpcode, Decode, InstFormat, Instruction, Isa, OpcodeKind};
use riscv_rt::entry;

#[entry]
#[allow(clippy::empty_loop)]
fn main() -> ! {
    assert_eq!(
        0b1111_1111_1001_1111_1111_0000_0110_1111_u32.decode(Isa::Rv64),
        Ok(Instruction {
            opc: OpcodeKind::BaseI(BaseIOpcode::JAL),
            rd: Some(0),
            rs1: None,
            rs2: None,
            imm: Some(-8),
            inst_format: InstFormat::JFormat,
        })
    );
    loop {}
}
```