### PR TITLE
Ver 1.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: softprops/action-gh-release@v1
+      - uses: actions/checkout@v4
+      - uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raki"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 authors = ["Norimasa Takana <alignof@outlook.com>"]
 repository = "https://github.com/Alignof/raki"

--- a/src/decode/inst_16.rs
+++ b/src/decode/inst_16.rs
@@ -26,6 +26,7 @@ impl Decode for u16 {
             rs2: new_rs2,
             imm: new_imm,
             inst_format: new_fmt,
+            is_compressed: true,
         })
     }
 

--- a/src/decode/inst_32.rs
+++ b/src/decode/inst_32.rs
@@ -28,6 +28,7 @@ impl Decode for u32 {
             rs2: new_rs2,
             imm: new_imm,
             inst_format: new_fmt,
+            is_compressed: false,
         })
     }
 

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -37,6 +37,8 @@ pub struct Instruction {
     pub imm: Option<i32>,
     /// Instruction format
     pub inst_format: InstFormat,
+    /// Is compressed instruction?
+    pub is_compressed: bool,
 }
 
 impl Display for Instruction {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,9 @@ mod instruction;
 pub use crate::decode::{Decode, DecodingError};
 pub use crate::instruction::{
     a_extension::AOpcode, base_i::BaseIOpcode, c_extension::COpcode, m_extension::MOpcode,
-    priv_extension::PrivOpcode, zicntr_extension::ZicntrOpcode, zicsr_extension::ZicsrOpcode,
-    zifencei_extension::ZifenceiOpcode, InstFormat, Instruction, OpcodeKind,
+    priv_extension::PrivOpcode, zicfiss_extension::ZicfissOpcode, zicntr_extension::ZicntrOpcode,
+    zicsr_extension::ZicsrOpcode, zifencei_extension::ZifenceiOpcode, InstFormat, Instruction,
+    OpcodeKind,
 };
 
 /// Target isa.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ mod tests {
                 rs2: None,
                 imm: Some(-8),
                 inst_format: InstFormat::JFormat,
+                is_compressed: false,
             })
         );
 
@@ -114,6 +115,7 @@ mod tests {
                 rs2: Some(2),
                 imm: None,
                 inst_format: InstFormat::CrFormat,
+                is_compressed: true,
             })
         );
 
@@ -126,6 +128,7 @@ mod tests {
                 rs2: Some(2),
                 imm: None,
                 inst_format: InstFormat::CrFormat,
+                is_compressed: true,
             })
         );
 
@@ -152,6 +155,7 @@ mod tests {
                 rs2: None,
                 imm: Some(-8),
                 inst_format: InstFormat::JFormat,
+                is_compressed: false,
             })
         );
 


### PR DESCRIPTION
- Export `zicfiss_extension::ZicfissOpcode`.
- Add `Instruction.is_compressed`.