### PR TITLE
Fix U-type immediate decoding

### DIFF
--- a/src/decode/base_i.rs
+++ b/src/decode/base_i.rs
@@ -273,7 +273,7 @@ pub mod bit_32 {
     #[allow(clippy::cast_possible_wrap)]
     #[allow(non_snake_case)]
     pub fn parse_imm(inst: u32, opkind: &BaseIOpcode, isa: Isa) -> Option<i32> {
-        let U_type = || (inst.slice(31, 12) << 12) as i32;
+        let U_type = || inst.slice(31, 12) as i32;
         let I_type = || {
             let imm32 = inst.slice(31, 20) as i32;
             inst.to_signed_nbit(imm32, 12)

--- a/src/decode/base_i.rs
+++ b/src/decode/base_i.rs
@@ -348,28 +348,52 @@ mod test_basei {
         use crate::OpcodeKind;
 
         test_32_in_rv64(
-            0b1000_0000_0000_0000_0000_0000_1011_0111,
+            0xfdead737,
             OpcodeKind::BaseI(BaseIOpcode::LUI),
+            Some(14),
+            None,
+            None,
+            Some(0xfdead),
+        );
+        test_32_in_rv64(
+            0x1597,
+            OpcodeKind::BaseI(BaseIOpcode::AUIPC),
+            Some(11),
+            None,
+            None,
+            Some(0x1),
+        );
+        test_32_in_rv64(
+            0x013f9517,
+            OpcodeKind::BaseI(BaseIOpcode::AUIPC),
+            Some(10),
+            None,
+            None,
+            Some(0x13f9),
+        );
+        test_32_in_rv64(
+            0x009bc097,
+            OpcodeKind::BaseI(BaseIOpcode::AUIPC),
             Some(1),
             None,
             None,
-            Some(0x8000_0000),
+            Some(0x9bc),
         );
         test_32_in_rv64(
-            0b0000_0000_0000_0000_0000_0010_1001_0111,
-            OpcodeKind::BaseI(BaseIOpcode::AUIPC),
-            Some(5),
-            None,
-            None,
-            Some(0),
-        );
-        test_32_in_rv64(
-            0b1111_1111_1001_1111_1111_0000_0110_1111,
+            0x9d3ff0ef,
             OpcodeKind::BaseI(BaseIOpcode::JAL),
-            Some(0),
+            Some(1),
             None,
             None,
-            Some(-8),
+            Some(-1582),
+        );
+        test_32_in_rv64(
+            0x02e78263,
+            OpcodeKind::BaseI(BaseIOpcode::BEQ),
+            None,
+            Some(15),
+            Some(14),
+            Some(36),
         );
         test_32_in_rv64(
             0b1111_1110_0010_0000_1000_1110_1010_0011,

--- a/src/decode/inst_16.rs
+++ b/src/decode/inst_16.rs
@@ -178,10 +178,10 @@ pub fn test_16(
         location.line()
     );
 }
-
 #[cfg(test)]
 #[track_caller]
-pub fn test_16_in_rv16(
+#[allow(dead_code)]
+pub fn test_16_in_rv32(
     inst_16: u16,
     op: OpcodeKind,
     rd: Option<usize>,

--- a/src/decode/inst_32.rs
+++ b/src/decode/inst_32.rs
@@ -266,6 +266,7 @@ pub fn test_32(
 
 #[cfg(test)]
 #[track_caller]
+#[allow(dead_code)]
 pub fn test_32_in_rv32(
     inst_32: u32,
     op: OpcodeKind,


### PR DESCRIPTION
The immediate in U-type is shifted right 12 bits but it should be do by **user** (**NOT library**).
https://github.com/Alignof/raki/blob/754a26ed48e129f274530477bd3200d8bcaaaa16/src/decode/base_i.rs#L276
Thus this process must be removed from this library.

Fix #37 